### PR TITLE
chore: .gitignore에 dev, oauth profile 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application-oauth.yml
+src/main/resources/application-dev.yml


### PR DESCRIPTION
profile 중 dev, oauth 환경을 gitignore에 추가

공유되면 안되는 값이 있기 때문
관련 파일은 이전에 디스코드에 공유했던 파일 다시 옮겨서 사용 부탁드립니다.