### PR TITLE
Chore: 보드에 멤버 연관관계 추가

### DIFF
--- a/src/main/java/com/example/hanghaegg/domain/matching/config/S3Config.java
+++ b/src/main/java/com/example/hanghaegg/domain/matching/config/S3Config.java
@@ -21,7 +21,8 @@ public class S3Config {
 	@Bean
 	public AmazonS3Client amazonS3Client() {
 		BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
-		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+		return (AmazonS3Client)AmazonS3ClientBuilder
+			.standard()
 			.withRegion(region)
 			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
 			.build();

--- a/src/main/java/com/example/hanghaegg/domain/matching/controller/BoardController.java
+++ b/src/main/java/com/example/hanghaegg/domain/matching/controller/BoardController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,9 +29,10 @@ public class BoardController {
 	@PostMapping("/matches")
 	public ResponseEntity<BoardResponse> createBoard(
 		@RequestPart(value = "data") final BoardRequest boardRequest,
-		@RequestPart(value = "img") final MultipartFile file) {
+		@RequestPart(value = "img") final MultipartFile file,
+		User user){
 
-		boardService.createBoard(boardRequest, file);
+		boardService.createBoard(boardRequest, file, user);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/src/main/java/com/example/hanghaegg/domain/matching/dto/BoardRequest.java
+++ b/src/main/java/com/example/hanghaegg/domain/matching/dto/BoardRequest.java
@@ -13,14 +13,14 @@ public class BoardRequest {
 	private String title;
 	private String content;
 
-	private String img;
+	// private String img;
 
 
-	public static Board toEntity(BoardRequest request) {
-		return Board.of(
-			request.getTitle(),
-			request.getContent(),
-			request.getImg()
-		);
-	}
+	// public static Board toEntity(BoardRequest request) {
+	// 	return Board.of(
+	// 		request.getTitle(),
+	// 		request.getContent(),
+	// 		request.getImg()
+	// 	);
+	// }
 }

--- a/src/main/java/com/example/hanghaegg/domain/matching/entity/Board.java
+++ b/src/main/java/com/example/hanghaegg/domain/matching/entity/Board.java
@@ -1,10 +1,18 @@
 package com.example.hanghaegg.domain.matching.entity;
 
+import java.util.Optional;
+
+import com.example.hanghaegg.domain.matching.dto.BoardRequest;
+import com.example.hanghaegg.domain.member.entity.Member;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,15 +32,22 @@ public class Board {
 	@Column(nullable = false)
 	private String content;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "memberId")
+	private Member member;
+
 	private String img;
 
-	private Board(String title, String content, String img) {
-		this.title = title;
-		this.content = content;
+	public Board(BoardRequest boardRequest, Member member, String img) {
+		this.title = boardRequest.getTitle();
+		this.content = boardRequest.getContent();
+		this.member = member;
 		this.img = img;
 	}
 
-	public static Board of(String title, String content, String img) {
-		return new Board(title, content, img);
-	}
+	//TODO: private 생성자 추가
+
+	// public static Board of(String title, String content, String img) {
+	// 	return new Board(title, content, img);
+	// }
 }

--- a/src/main/java/com/example/hanghaegg/domain/matching/service/BoardService.java
+++ b/src/main/java/com/example/hanghaegg/domain/matching/service/BoardService.java
@@ -1,8 +1,10 @@
 package com.example.hanghaegg.domain.matching.service;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +16,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.hanghaegg.domain.matching.dto.BoardRequest;
 import com.example.hanghaegg.domain.matching.entity.Board;
 import com.example.hanghaegg.domain.matching.repository.BoardRepository;
+import com.example.hanghaegg.domain.member.entity.Member;
+import com.example.hanghaegg.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BoardService {
 
+	private final MemberRepository memberRepository;
 	private final BoardRepository boardRepository;
 	private final AmazonS3Client amazonS3Client;
 	private String S3Bucket = "board-img";
@@ -54,13 +59,16 @@ public class BoardService {
 	// }
 
 	@Transactional
-	public void createBoard(final BoardRequest boardRequest, final MultipartFile file) {
+	public void createBoard(final BoardRequest boardRequest, final MultipartFile file, User user) {
 
 		String imagePath = saveImg(file);
-		// boardDto.setMember(member);
-		boardRequest.setImg(imagePath);
+		// boardDto.setMember(user);
+		// boardRequest.setImg(imagePath);
 
-		Board board = boardRepository.saveAndFlush(BoardRequest.toEntity(boardRequest));
+		String mail = user.getUsername();
+		Member member = memberRepository.findByMail(mail);
+		Board board = new Board(boardRequest, member, imagePath);
+		boardRepository.saveAndFlush(board);
 	}
 
 	// @Transactional

--- a/src/main/java/com/example/hanghaegg/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/hanghaegg/domain/member/repository/MemberRepository.java
@@ -11,6 +11,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByEmail(String email);
 
+	Member findByMail(String email);
+
 	Optional<Member> findByNickname(String nickname);
 
 	Optional<Member> findByRefreshToken(String refreshToken);


### PR DESCRIPTION
보드 엔티티에 멤버 컬럼 추가, 보드 생성시 멤버 지정 로직 추가
+하나님 테스트 급하신 것 같아서 빠르게 연관관계 매핑하느라 나머지 코드가 난잡합니다. 후에 리팩토링 하겠습니다.